### PR TITLE
Adding Ready Count

### DIFF
--- a/pkg/fleet/overview.go
+++ b/pkg/fleet/overview.go
@@ -68,8 +68,8 @@ func nodesOverview(cfg api.Config, context string) (string, error) {
 	nodes, err := cs.CoreV1().Nodes().List(metav1.ListOptions{})
 	nodeCount := len(nodes.Items)
 	readyCount := 0
-	for _, node in nodes.Items {
-		for _, nodeCondition in node.Status.Conditions {
+	for _, node := range nodes.Items {
+		for _, nodeCondition := range node.Status.Conditions {
 			if nodeCondition.Type == "Ready" {
 				if nodeCondition.Status == "True" {
 					readyCount++	

--- a/pkg/fleet/overview.go
+++ b/pkg/fleet/overview.go
@@ -66,10 +66,22 @@ func nodesOverview(cfg api.Config, context string) (string, error) {
 		return "", errors.Wrap(err, "Can't create a clientset based on config provided")
 	}
 	nodes, err := cs.CoreV1().Nodes().List(metav1.ListOptions{})
+	nodeCount := len(nodes.Items)
+	readyCount := 0
+	for _, node in nodes.Items {
+		for _, nodeCondition in node.Status.Conditions {
+			if nodeCondition.Type == "Ready" {
+				if nodeCondition.Status == "True" {
+					readyCount++	
+				}
+				break	
+			}
+		}
+	}
 	if err != nil {
 		return "", errors.Wrap(err, "Can't get nodes in cluster")
 	}
-	noverview := fmt.Sprintf("%v", len(nodes.Items))
+	noverview := fmt.Sprintf("%v/%v", readyCount, nodeCount)
 	return noverview, nil
 }
 


### PR DESCRIPTION
I wanted to offer this change, this is something I would find very helpful when working with a fleet of clusters is seeing of the nodes on each cluster how much are currently Ready. It would be a great way to quickly find clusters that have downed nodes. I ran a quick test, but I don't have access to any clusters with non-ready nodes currently.