### PR TITLE
Adding oidc (dex style) authentication to fleet

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"github.com/mhausenblas/kcf/cmd/fleet/cli"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // required for GKE
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // required for oidc authentication
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for GKE/OIDC/Dex style auth
 )
 
 func main() {

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"github.com/mhausenblas/kcf/cmd/fleet/cli"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // required for GKE
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // required for GKE
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // required for oidc authentication
 )
 
 func main() {

--- a/pkg/fleet/overview.go
+++ b/pkg/fleet/overview.go
@@ -72,9 +72,9 @@ func nodesOverview(cfg api.Config, context string) (string, error) {
 		for _, nodeCondition := range node.Status.Conditions {
 			if nodeCondition.Type == "Ready" {
 				if nodeCondition.Status == "True" {
-					readyCount++	
+					readyCount++
 				}
-				break	
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Without this you get

```
$ kubectl fleet details mycluster
API server endpoint: https://k8s-master.mycluster.me.cloud:443
No Auth Provider found for name "oidc"
```