### PR TITLE
update template file to match krew-index spec file

### DIFF
--- a/deploy/krew/fleet.yaml
+++ b/deploy/krew/fleet.yaml
@@ -40,17 +40,14 @@ spec:
     bin: "fleet.exe"
   shortDescription: Shows config and resources of a fleet of clusters
   homepage: https://github.com/kubectl-plus/kcf
-  caveats: |
-    Usage:
-      $ kubectl fleet
-
-    For additional options:
-      $ kubectl fleet --help
-      or https://github.com/kubectl-plus/kcf/blob/v0.1.4/doc/USAGE.md
-
   description: |
     Allows to get an overview and details on a fleet of Kubernetes clusters.
     The top-level command lists all active clusters found in the kubeconfig provided.
     For each cluster, configuration info such as the control plane version or 
     API server endpoint are displayed, as well as select stats, for example, 
     the number of worker nodes or namespaces found in the cluster.
+
+    For additional options:
+      $ kubectl fleet --help
+      or https://github.com/kubectl-plus/kcf/blob/v0.1.4/doc/USAGE.md
+


### PR DESCRIPTION
The template in krew-index was updated as part of this commit: https://github.com/kubernetes-sigs/krew-index/commit/609240e21f6089805cba46af5fddfd41e2cbf6b2

We should update our template file to allow auto-merge of PR's opened by krew-release-bot. Current PR didnt get auto approved due to this diff.

Thanks
Rajat Jindal